### PR TITLE
Update build instructions for custom Debian image

### DIFF
--- a/bootmem/Makefile.debian_custom_cpio
+++ b/bootmem/Makefile.debian_custom_cpio
@@ -1,0 +1,73 @@
+# Define certain global variables
+CROSS_COMPILE?=riscv64-unknown-linux-gnu-
+MKDIR?=mkdir
+CC=$(CROSS_COMPILE)gcc
+OBJCOPY=$(CROSS_COMPILE)objcopy
+
+# Debian build
+DEBIAN_CONFIG?=$(CURDIR)/debian-linux.config
+
+$(info DEBIAN_CONFIG=$(DEBIAN_CONFIG))
+
+# Build and source directories
+LINUX_SRC=../riscv-linux
+BBL_SRC=../../riscv-pk
+
+# Export variables
+export CROSS_COMPILE
+
+# For faster builds, use all available cores
+UNAME = $(shell uname -s)
+NPROCS:=1
+ifeq ($(UNAME),Linux)
+        NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
+else ifeq ($(UNAME),Darwin)
+        NPROCS := $(shell sysctl hw.ncpu | awk '{print $$2}')
+endif
+# Limit NPROCS to 8 so qemu can handle it
+
+default: debian
+debian: build-debian-bbl/bbl bootmem-debian.bin
+
+.PHONY: default debian clean
+
+# Linux kernel
+# Statically linked linux kernel executable, has CONFIG_INITRAMFS_SOURCE baked in it
+# For debian, we have `CONFIG_INITRAMFS_SOURCE="../debian.cpio.gz"`, so debian.cpio.gz must be in place
+# in this directory.
+# DEBIAN_CONFIG provides linux kernel configuration
+build-debian-linux/vmlinux: $(DEBIAN_CONFIG) debian.cpio.gz
+	@echo "Building Linux with config: $$DEBIAN_CONFIG"
+	export KCONFIG_CONFIG=$(DEBIAN_CONFIG) && $(MAKE) -C $(LINUX_SRC) -j$(NPROCS) ARCH=riscv O=$(CURDIR)/build-debian-linux olddefconfig
+	export KCONFIG_CONFIG=$(DEBIAN_CONFIG) && $(MAKE) -C $(@D) -j$(NPROCS) ARCH=riscv O=$(CURDIR)/build-debian-linux $(@F)
+	@echo "build-qemu-linux/vmlinux done"
+
+# Debian binary (linux kernel + rootfs) + bootloader - for loading through GDB
+build-debian-bbl/bbl: build-debian-linux/vmlinux
+	@echo "build-debian-bbl/bbl"
+	$(MKDIR) -p $(@D)
+	cd $(@D) && $(BBL_SRC)/configure --host=riscv64-unknown-elf --with-payload=../build-debian-linux/vmlinux --enable-zero-bss --with-mem-start=0xC0000000
+	$(MAKE) -C $(@D) -j$(NPROCS)
+	@echo "build-debian-bbl/bbl done"
+
+# Intermediate stripped debian binary + bootloader
+bbl-debian.bin: build-debian-bbl/bbl
+	$(OBJCOPY) -O binary $< $@
+
+# Intermediate ELF file for booting debian from flash
+bootmem-debian: bootmem.S linker.ld bbl-debian.bin
+	@rm -rf bbl.bin
+	@ln -s bbl-debian.bin bbl.bin
+	$(CC) -Tlinker.ld $< -nostdlib -static -Wl,--no-gc-sections -o $@
+
+# Stripped Binary file for booting debian from flash
+bootmem-debian.bin: bootmem-debian
+	$(OBJCOPY) -O binary $< $@
+
+# Clean all debian build artifacts
+clean:
+	@rm -f bootmem-debian bootmem-debian.bin bbl-debian.bin
+	@rm -rf build-debian-bbl
+	@rm -rf build-debian-linux
+	@rm -rf debian-linux.config.old
+

--- a/debian/Makefile
+++ b/debian/Makefile
@@ -9,6 +9,8 @@ riscv64-chroot:
 	./create_chroot.sh
 
 $(BOOTMEM_DIR)/debian.cpio.gz: riscv64-chroot
+	@echo "Cleaning up apt remnants"
+	./create_chroot.sh apt_cleanup
 	@echo "Building cpio.gz image"
 	./create_chroot.sh create_cpio
 	cp riscv64-chroot/debian.cpio.gz $@

--- a/debian/create_chroot.sh
+++ b/debian/create_chroot.sh
@@ -38,7 +38,7 @@ build_dir="$debian_dir/build"
 if [ -n "$GFE_DEBIAN_URL" ]; then
     debian_url="${GFE_DEBIAN_URL}"
 else
-    debian_url="http://deb.debian.org/debian-ports/"
+    debian_url="http://snapshot.debian.org/archive/debian-ports/20200101T030944Z"
 fi
 
 : ${DEBIAN_PORTS_ARCHIVE_KEYRING:=/usr/share/keyrings/debian-ports-archive-keyring.gpg}
@@ -171,6 +171,7 @@ stage1_inner() {
         --no-merged-usr \
         --keyring $DEBIAN_PORTS_ARCHIVE_KEYRING \
         --verbose \
+	--exclude=usr-is-merged \
         sid $chroot_dir $debian_url
 
     # Manually unpack fakeroot + libfakeroot into the build dir.  We don't
@@ -208,6 +209,10 @@ main() {
 
 create_cpio() {
     in_chroot "/host-rootfs/$debian_dir/setup_scripts/create_cpio.sh"
+}
+
+apt_cleanup() {
+    in_chroot "/host-rootfs/$debian_dir/setup_scripts/apt_cleanup.sh"
 }
 
 

--- a/debian/setup_chroot.sh
+++ b/debian/setup_chroot.sh
@@ -5,6 +5,11 @@ set -e
 # customize it to change the set of packages installed or to set up custom
 # configuration files.
 
+# The keys for the Debian snapshots archive will likely have expired by
+# now, interfering with apt operations in the chroot. allow-insecure
+# bypasses the signatures checks
+sed -i 's/deb /deb [allow-insecure=yes] /' /etc/apt/sources.list
+
 debian_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 setup_scripts_dir="${debian_dir}/setup_scripts"
 
@@ -54,8 +59,3 @@ fi
 # Remove debconf internationalization for debconf
 dpkg --remove debconf-i18n
 
-# apt-get then cleanup
-apt-get update
-apt-get autoremove -y
-apt-get clean
-rm -f /var/lib/apt/lists/*debian*

--- a/debian/setup_scripts/apt_cleanup.sh
+++ b/debian/setup_scripts/apt_cleanup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+# apt-get cleanup
+apt-get autoremove -y
+apt-get clean
+rm -f /var/lib/apt/lists/*debian*


### PR DESCRIPTION
Updates the instructions for building custom Debian images outside of the Nix environment provided by BESSPIN-Environment. A couple of notes:

- The debian-ports archive is now pinned to a past snapshot. Recent updates to the libc in sid result in incompatibilities with the version of QEMU provided in Debian 10, causing some of the QEMU-based actions to fail if not using a snapshot.

- The signing keys for the snapshotted archive have long since expired, causing signature verification problems when using apt. Those issues can be side stepped if building the filesystem in a virtual machine, but just working in a chroot there's not a clean way to turn back time. While this doesn't make me happy, the best solution that I could find was to disable signature checks for the snapshot archive.

- When trying to use the original Makefile in bootmem, I ran into some problem where the system wouldn't fully boot under QEMU, which interfered with the chainloader process. I haven't tried to diagnose that problem, and instead have just de-emphasized the use of the original Makefile in the instructions.